### PR TITLE
Fix ambiguous function name

### DIFF
--- a/src/Common/Infrastructure/Dto.php
+++ b/src/Common/Infrastructure/Dto.php
@@ -391,7 +391,7 @@ abstract class Dto implements Serializable
 
         $properties = [];
 
-        if (preg_match_all('/@property(-read|-write|)[^$]+\$([^\s]+)/i', $this->getComment(), $matches)) {
+        if (preg_match_all('/@property(-read|-write|)[^$]+\$([^\s]+)/i', $this->extractComment(), $matches)) {
             foreach ($matches[1] as $i => $type) {
                 if ($type === '-read') {
                     $type = self::PROP_TYPE_READ;
@@ -425,7 +425,7 @@ abstract class Dto implements Serializable
         self::$properties[static::class] = $properties;
     }
 
-    private function getComment(): string
+    private function extractComment(): string
     {
         $comment = '';
         $class = $this->reflector;


### PR DESCRIPTION
Because of "getComment" function that should get DocComments, you can not create property called "comment" without implementing "getComment" on your Dto, because parser will find private "getComment" and associate it with field, but this is wrong and unexpected. 

So renaming will prevent name collision