### PR TITLE
Add ability to set default complex objects

### DIFF
--- a/src/Common/Infrastructure/Dto.php
+++ b/src/Common/Infrastructure/Dto.php
@@ -52,6 +52,7 @@ abstract class Dto implements Serializable
      */
     public function __construct(array $properties = [], bool $strict = true)
     {
+        $properties = array_merge($this->getDefaultValues(), $properties);
         $this->init();
         $this->assignPropertiesAndValidate($properties, $strict);
     }
@@ -314,6 +315,16 @@ abstract class Dto implements Serializable
                 $this->invokeValidator($validator);
             }
         }
+    }
+
+    /**
+     * Sets default values for DTO for complex non-nullable properties
+     *
+     * @return array
+     */
+    protected function getDefaultValues(): array
+    {
+        return [];
     }
 
     private function checkPropertyExistence(string $property): void

--- a/src/Common/Infrastructure/Dto.php
+++ b/src/Common/Infrastructure/Dto.php
@@ -52,7 +52,7 @@ abstract class Dto implements Serializable
      */
     public function __construct(array $properties = [], bool $strict = true)
     {
-        $properties = array_merge($this->getDefaultValues(), $properties);
+        $properties = array_merge($this->getDefaultPropertyValues(), $properties);
         $this->init();
         $this->assignPropertiesAndValidate($properties, $strict);
     }
@@ -322,7 +322,7 @@ abstract class Dto implements Serializable
      *
      * @return array
      */
-    protected function getDefaultValues(): array
+    protected function getDefaultPropertyValues(): array
     {
         return [];
     }


### PR DESCRIPTION
If we have entity like this:

```
class SomeEntity extends Entity
{
    private string $name;
    private EntityStatus $status;
}
```

EntityStatus is enum and it always NEW for every new entity.  Now there are two methods how to set that:
1. Every time pass property when create new object (very bad approach)
2. Overwrite constructor (better but not comfortable)

This PR introduce new method: `getDefaultValues` which sets default values 