### PR TITLE
Add UUID7 support to GlobalId

### DIFF
--- a/src/Common/Model/Identity/GlobalId.php
+++ b/src/Common/Model/Identity/GlobalId.php
@@ -12,6 +12,7 @@ namespace AlephTools\DDD\Common\Model\Identity;
 class GlobalId extends AbstractId
 {
     public const UUID4_PATTERN = '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$';
+    public const UUID7_PATTERN = '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-7[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$';
 
     /**
      * Generates new global identifier.
@@ -20,6 +21,15 @@ class GlobalId extends AbstractId
     public static function create(): static
     {
         return new static(self::uuid4());
+    }
+
+    /**
+     * Generates new global identifier using UUID v7 (time-ordered).
+     *
+     */
+    public static function create7(): static
+    {
+        return new static(self::uuid7());
     }
 
     /**
@@ -35,6 +45,45 @@ class GlobalId extends AbstractId
     }
 
     /**
+     * Generates new uuid7 (time-ordered UUID)
+     * Implementation optimized for high performance
+     *
+     */
+    private static function uuid7(): string
+    {
+        // Get current Unix timestamp in milliseconds (48 bits)
+        $timestampMs = (int)(microtime(true) * 1000);
+
+        // Convert to 6-byte big-endian representation
+        $timestampBytes = pack('J', $timestampMs);
+        $timestampBytes = substr($timestampBytes, -6);
+
+        // Generate 10 random bytes (80 bits) for the random portion
+        $randomBytes = random_bytes(10);
+
+        // Combine timestamp (6 bytes) + random (10 bytes) = 16 bytes total
+        $uuidBytes = $timestampBytes . $randomBytes;
+
+        // Set version to 0111 (UUID v7) in the most significant 4 bits of byte 6
+        $uuidBytes[6] = chr(ord($uuidBytes[6]) & 0x0f | 0x70);
+
+        // Set variant to 10 in the most significant 2 bits of byte 8
+        $uuidBytes[8] = chr(ord($uuidBytes[8]) & 0x3f | 0x80);
+
+        // Convert to hexadecimal string with UUID formatting
+        $hex = bin2hex($uuidBytes);
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12)
+        );
+    }
+
+    /**
      * Returns TRUE if the given identity can be a global identifier.
      *
      */
@@ -45,7 +94,8 @@ class GlobalId extends AbstractId
         }
 
         if (is_string($identity)) {
-            return (bool)preg_match('/' . self::UUID4_PATTERN . '/D', $identity);
+            return (bool)preg_match('/' . self::UUID4_PATTERN . '/D', $identity) ||
+                   (bool)preg_match('/' . self::UUID7_PATTERN . '/D', $identity);
         }
 
         return false;

--- a/tests/Common/Model/Identity/GlobalIdTest.php
+++ b/tests/Common/Model/Identity/GlobalIdTest.php
@@ -39,6 +39,15 @@ class GlobalIdTest extends TestCase
         self::assertTrue(GlobalId::canBeId($id->identity));
     }
 
+    public function testNewId7(): void
+    {
+        $id = GlobalId::create7();
+
+        self::assertInstanceOf(GlobalId::class, $id);
+        self::assertTrue(GlobalId::canBeId($id->identity));
+        self::assertSame('7', substr($id->identity, 14, 1));
+    }
+
     public function testCanBeId(): void
     {
         $identity = 'b5e2cf01-8bb6-4fcd-ad88-0efb611195da';
@@ -53,9 +62,31 @@ class GlobalIdTest extends TestCase
         self::assertFalse(GlobalId::canBeId(null));
     }
 
+    public function testCanBeId7(): void
+    {
+        // Valid UUID7 examples
+        $validUuid7 = '019a005c-330a-7417-b3e5-829eaa6c10ee';
+
+        self::assertTrue(GlobalId::canBeId($validUuid7));
+        self::assertTrue(GlobalId::canBeId(GlobalId::create7()));
+
+        // Invalid UUID7 examples
+        self::assertFalse(GlobalId::canBeId('019a005c-330a-6417-b3e5-829eaa6c10ee')); // version 6
+        self::assertFalse(GlobalId::canBeId('019a005c-330a-7417-b3e5-829eaa6c10ee0')); // too long
+        self::assertFalse(GlobalId::canBeId('019a005c-330a-7417-c3e5-829eaa6c10ee')); // invalid variant
+    }
+
     public function testParseGlobalId(): void
     {
         $id = GlobalId::create();
+        $copy = new GlobalId($id);
+
+        self::assertSame($id->identity, $copy->identity);
+    }
+
+    public function testParseGlobalId7(): void
+    {
+        $id = GlobalId::create7();
         $copy = new GlobalId($id);
 
         self::assertSame($id->identity, $copy->identity);
@@ -116,5 +147,54 @@ class GlobalIdTest extends TestCase
 
         self::assertSame($id->identity, GlobalId::fromNullable($id->identity)?->identity);
         self::assertNull(GlobalId::fromNullable(null));
+    }
+
+    public function testUuid7ChronologicalOrder(): void
+    {
+        $uuids = [];
+        for ($i = 0; $i < 5; $i++) {
+            $uuids[] = GlobalId::create7();
+            usleep(1000); // 1ms delay to ensure different timestamps
+        }
+
+        // Extract the identities as strings for comparison
+        $identities = array_map(fn($id) => $id->identity, $uuids);
+        $sorted = $identities;
+        sort($sorted);
+
+        // UUID7 should be roughly chronological (allowing for some variance due to random bits)
+        // Since we have small delays, most UUIDs should be in chronological order
+        self::assertGreaterThanOrEqual(3, count(array_intersect_assoc($identities, $sorted)));
+    }
+
+    public function testUuid7Uniqueness(): void
+    {
+        $uuids = [];
+        $count = 1000;
+
+        for ($i = 0; $i < $count; $i++) {
+            $uuids[] = GlobalId::create7()->identity;
+        }
+
+        $uniqueUuids = array_unique($uuids);
+
+        self::assertSame($count, count($uniqueUuids), 'All UUID7 should be unique');
+    }
+
+    public function testUuid7Performance(): void
+    {
+        $count = 10000;
+        $start = microtime(true);
+
+        for ($i = 0; $i < $count; $i++) {
+            GlobalId::create7();
+        }
+
+        $time = microtime(true) - $start;
+        $performance = $count / $time;
+
+        // Should be able to generate at least 100,000 UUID7 per second
+        self::assertGreaterThan(100000, $performance,
+            "UUID7 generation should be fast. Got: " . number_format($performance) . " UUID/sec");
     }
 }


### PR DESCRIPTION
- Implement `create7` method for generating UUID7 (time-ordered) in `GlobalId`.
- Add UUID7 validation pattern and extend `canBeId` method to support UUID v7.
- Add comprehensive tests for UUID7 functionality: generation, validation, uniqueness, chronological order, and performance.